### PR TITLE
Win32Utils / account_info 함수 수정

### DIFF
--- a/_MyLib_test.cpp
+++ b/_MyLib_test.cpp
@@ -290,7 +290,7 @@ void run_test()
 	
 	//assert_bool(true, test_file_info_cache);
 	//
-	//assert_bool(true, test_process_token);
+	assert_bool(true, test_process_token);
 	//assert_bool(true, test_is_executable_file_w);
 	//assert_bool(true, test_singleton);
 	//assert_bool(true, test_std_move);	
@@ -1468,11 +1468,11 @@ bool test_get_account_infos()
 		unixtime_to_filetime(account->last_logon_timestamp(), &logon_filetime);
 		std::wstring last_logon_kst = MbsToWcsEx(file_time_to_str(&logon_filetime, true, false).c_str());
 		log_info
-			"name(%ws) : sid(%ws) priv(%ws) attrib(%ws) last_logon(%ws) log_on_count(%u) last_password_change(%u)",
+			"name(%ws) : sid(%ws) priv(%ws) attrib(%d) last_logon(%ws) log_on_count(%u) last_password_change(%u)",
 			account->name().c_str(),
 			account->sid().c_str(),
 			account->privilege(),
-			account->attribute_to_string().c_str(),
+			account->flags(),
 			last_logon_kst.c_str(),
 			account->num_logons(),
 			account->password_age()

--- a/_test_process_token.cpp
+++ b/_test_process_token.cpp
@@ -62,7 +62,7 @@ bool test_process_token()
 					}
 					
 					strm << L"sid=" << group_sid->_sid_info->_sid << L", ";
-					strm << L"attribute=" << group_sid->attribute();
+					strm << L"attribute=" << group_sid->_attribute;
 
 					log_info "    %ws", strm.str().c_str() log_end;
 					delete group_sid;
@@ -86,10 +86,7 @@ bool test_process_token()
 				{
 					std::wstringstream strm;
 					strm << L"privilege=" << privilege->_name;
-					if (0 != privilege->_attribute)
-					{
-						strm << L", attribute=" << privilege->attribute();
-					}
+					strm << L", attribute=" << privilege->_attribute;
 					log_info "        %ws", strm.str().c_str() log_end;
 					delete privilege;
 				}

--- a/src/Win32Utils.cpp
+++ b/src/Win32Utils.cpp
@@ -6423,6 +6423,188 @@ void dump_file_create_options(_In_ uint32_t NtCreateFile_CreateOptions)
 	}
 }
 
+void dump_group_attributes(_In_ uint32_t group_attributes)
+{
+	char buf[256];
+	char* pos = buf;
+	size_t remain = sizeof(buf);
+	bool add_lf = false;
+
+	if (FlagOn(group_attributes, SE_GROUP_MANDATORY))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  "%s",
+						  "SE_GROUP_MANDATORY");
+		add_lf = true;
+	}
+
+	if (FlagOn(group_attributes, SE_GROUP_ENABLED_BY_DEFAULT))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_GROUP_ENABLED_BY_DEFAULT");
+		add_lf = true;
+	}
+	if (FlagOn(group_attributes, SE_GROUP_ENABLED))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_GROUP_ENABLED");
+		add_lf = true;
+	}
+	if (FlagOn(group_attributes, SE_GROUP_OWNER))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_GROUP_OWNER");
+		add_lf = true;
+	}
+	if (FlagOn(group_attributes, SE_GROUP_USE_FOR_DENY_ONLY))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_GROUP_USE_FOR_DENY_ONLY");
+		add_lf = true;
+	}
+	if (FlagOn(group_attributes, SE_GROUP_INTEGRITY))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_GROUP_INTEGRITY");
+		add_lf = true;
+	}
+	if (FlagOn(group_attributes, SE_GROUP_INTEGRITY_ENABLED))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_GROUP_INTEGRITY_ENABLED");
+		add_lf = true;
+	}
+	if (FlagOn(group_attributes, SE_GROUP_LOGON_ID))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_GROUP_LOGON_ID");
+		add_lf = true;
+	}
+	if (FlagOn(group_attributes, SE_GROUP_RESOURCE))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_GROUP_RESOURCE");
+		add_lf = true;
+	}
+
+	if (add_lf == true)
+	{
+		log_info "options=%s", buf log_end;
+	}
+	else
+	{
+		log_info "options=None" log_end;
+	}
+}
+
+void dump_privilege_attributes(_In_ uint32_t privilege_attributes)
+{
+	bool add_lf = false;
+	char buf[256];
+	char* pos = buf;
+	size_t remain = sizeof(buf);
+
+	if (FlagOn(privilege_attributes, SE_PRIVILEGE_ENABLED))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  "%s",
+						  "SE_PRIVILEGE_ENABLED");
+		add_lf = true;
+	}
+
+	if (FlagOn(privilege_attributes, SE_PRIVILEGE_ENABLED_BY_DEFAULT))
+	{
+
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "SE_PRIVILEGE_ENABLED_BY_DEFAULT");
+		add_lf = true;
+	}
+	if (FlagOn(privilege_attributes, SE_PRIVILEGE_REMOVED))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  "%s",
+						  "SE_PRIVILEGE_REMOVED");
+		add_lf = true;
+	}
+	if (FlagOn(privilege_attributes, SE_PRIVILEGE_USED_FOR_ACCESS))
+	{
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  "%s",
+						  "SE_PRIVILEGE_USED_FOR_ACCESS");
+		add_lf = true;
+	}
+	
+	if (add_lf == true)
+	{
+		log_info "options=%s", buf log_end;
+	}
+	else
+	{
+		log_info "options=None" log_end;
+	}
+}
+
 /// @brief	
 psid_info get_sid_info(_In_ PSID sid)
 {

--- a/src/Win32Utils.h
+++ b/src/Win32Utils.h
@@ -615,7 +615,10 @@ bool get_process_creation_time(_In_ HANDLE process_handle, _Out_ PFILETIME const
 void dump_file_create_disposition(_In_ uint32_t NtCreateFile_CreateDisposition);
 /// @brief NtCreateFile `CreateOptions`을 문자열로 덤프한다.
 void dump_file_create_options(_In_ uint32_t NtCreateFile_CreateOptions);
-
+/// @brief process group 정보 중 `attributes`을 문자열로 덤프한다.
+void dump_group_attributes(_In_ uint32_t group_attributes);
+/// @brief process privilege 정보 중 `attributes`을 문자열로 덤프한다.
+void dump_privilege_attributes(_In_ uint32_t privilege_attributes);
 
 #pragma todo("sid 관련코드-> windows_security.h 같은 거 하나 만들어서 이동시키자")
 
@@ -691,61 +694,6 @@ public:
 public:
 	psid_info _sid_info;
 	DWORD _attribute;
-
-	std::wstring attribute()
-	{
-		bool addlf = false;
-		std::wstringstream flag;
-
-		if (FlagOn(_attribute, SE_GROUP_MANDATORY))
-		{
-			flag << SE_GROUP_MANDATORY; addlf = true;
-		}
-
-		if (FlagOn(_attribute, SE_GROUP_ENABLED_BY_DEFAULT))
-		{
-			if (true == addlf){flag << L", ";} else {addlf = true;}
-			flag << L"SE_GROUP_ENABLED_BY_DEFAULT";
-		}
-		if (FlagOn(_attribute, SE_GROUP_ENABLED))
-		{
-			if (true == addlf) { flag << L", "; } else { addlf = true; }
-			flag << L"SE_GROUP_ENABLED";
-		}
-		if (FlagOn(_attribute, SE_GROUP_OWNER))
-		{
-			if (true == addlf) { flag << L", "; } else { addlf = true; }
-			flag << L"SE_GROUP_OWNER";
-		}
-		if (FlagOn(_attribute, SE_GROUP_USE_FOR_DENY_ONLY))
-		{
-			if (true == addlf) { flag << L", "; } else { addlf = true; }
-			flag << L"SE_GROUP_USE_FOR_DENY_ONLY";
-		}
-		if (FlagOn(_attribute, SE_GROUP_INTEGRITY))
-		{
-			if (true == addlf) { flag << L", "; } else { addlf = true; }
-			flag << L"SE_GROUP_INTEGRITY";
-		}
-		if (FlagOn(_attribute, SE_GROUP_INTEGRITY_ENABLED))
-		{
-			if (true == addlf) { flag << L", "; } else { addlf = true; }
-			flag << L"SE_GROUP_INTEGRITY_ENABLED";
-		}
-		if (FlagOn(_attribute, SE_GROUP_LOGON_ID))
-		{
-			if (true == addlf) { flag << L", "; } else { addlf = true; }
-			flag << L"SE_GROUP_LOGON_ID";
-		}
-		if (FlagOn(_attribute, SE_GROUP_RESOURCE))
-		{
-			if (true == addlf) { flag << L", "; } else { addlf = true; }
-			flag << L"SE_GROUP_RESOURCE";
-		}
-
-		return flag.str();
-	}
-
 }*pgroup_sid_info;
 
 bool get_process_group(_In_ DWORD pid, _Out_ std::list<pgroup_sid_info>& group);
@@ -767,38 +715,6 @@ public:
 public:
 	std::wstring _name;
 	DWORD _attribute;
-
-	std::wstring attribute()
-	{
-		bool addlf = false;
-		std::wstringstream flag;
-
-		if (FlagOn(_attribute, SE_PRIVILEGE_ENABLED))
-		{
-			flag << SE_PRIVILEGE_ENABLED; addlf = true;
-		}
-
-		if (FlagOn(_attribute, SE_PRIVILEGE_ENABLED_BY_DEFAULT))
-		{
-			if (true == addlf) { flag << L", "; }
-			else { addlf = true; }
-			flag << L"SE_PRIVILEGE_ENABLED_BY_DEFAULT";
-		}
-		if (FlagOn(_attribute, SE_PRIVILEGE_REMOVED))
-		{
-			if (true == addlf) { flag << L", "; }
-			else { addlf = true; }
-			flag << L"SE_PRIVILEGE_REMOVED";
-		}
-		if (FlagOn(_attribute, SE_PRIVILEGE_USED_FOR_ACCESS))
-		{
-			if (true == addlf) { flag << L", "; }
-			else { addlf = true; }
-			flag << L"SE_PRIVILEGE_USED_FOR_ACCESS";
-		}
-		return flag.str();
-	}
-
 } *pprivilege_info;
 
 pprivilege_info get_privilege_info(_In_ LUID_AND_ATTRIBUTES privileges);

--- a/src/account_info.cpp
+++ b/src/account_info.cpp
@@ -45,93 +45,177 @@ const wchar_t* account::privilege() const
 }
 
 /// @brief	계정 속성
-std::wstring account::attribute_to_string()
+void account::dump_account_flags()
 {
-	bool addlf = false;
-	std::wstringstream flag;
+	char buf[256];
+	char* pos = buf;
+	size_t remain = sizeof(buf);
+	bool add_lf = false;
+
 	if (FlagOn(_flags, UF_SCRIPT))
 	{
-		flag << "UF_SCRIPT"; addlf = true;
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  "%s",
+						  "UF_SCRIPT");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_ACCOUNTDISABLE))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_ACCOUNTDISABLE";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_ACCOUNTDISABLE");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_HOMEDIR_REQUIRED))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_HOMEDIR_REQUIRED";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_HOMEDIR_REQUIRED");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_PASSWD_NOTREQD))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_PASSWD_NOTREQD";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_PASSWD_NOTREQD");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_PASSWD_CANT_CHANGE))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_PASSWD_CANT_CHANGE";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_PASSWD_CANT_CHANGE");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_DONT_EXPIRE_PASSWD))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_DONT_EXPIRE_PASSWD";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_DONT_EXPIRE_PASSWD");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_NOT_DELEGATED))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_NOT_DELEGATED";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_NOT_DELEGATED");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_SMARTCARD_REQUIRED))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_SMARTCARD_REQUIRED";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_SMARTCARD_REQUIRED");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_USE_DES_KEY_ONLY))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_USE_DES_KEY_ONLY";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_USE_DES_KEY_ONLY");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_DONT_REQUIRE_PREAUTH))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_DONT_REQUIRE_PREAUTH";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_DONT_REQUIRE_PREAUTH");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_TRUSTED_FOR_DELEGATION))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_TRUSTED_FOR_DELEGATION";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_TRUSTED_FOR_DELEGATION");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_PASSWORD_EXPIRED))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_PASSWORD_EXPIRED";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_PASSWORD_EXPIRED");
+		add_lf = true;
 	}
 	if (FlagOn(_flags, UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION))
 	{
-		if (true == addlf) { flag << L", "; }
-		else { addlf = true; }
-		flag << L"UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION";
+		StringCbPrintfExA(pos,
+						  remain,
+						  &pos,
+						  &remain,
+						  0,
+						  (true == add_lf) ? ", %s" : "%s",
+						  "UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION");
+		add_lf = true;
 	}
-	return flag.str();
+
+
+	if (add_lf == true)
+	{
+		log_info "options=%s", buf log_end;
+	}
+	else
+	{
+		log_info "options=None" log_end;
+	}
 }
 
 /// @brief `PSID`를 문자열로 변환 한다. 

--- a/src/account_info.h
+++ b/src/account_info.h
@@ -39,7 +39,10 @@ public:
 	const wchar_t* privilege() const;
 
 	// 계정 속성
-	std::wstring attribute_to_string();
+	uint32_t flags() { return _flags; }
+
+	// 계정 속성 덤프
+	void dump_account_flags();
 
 	// 사용자 로그온시 동작하는 스크립트의 경로
 	std::wstring script_path() { return _script_path; };


### PR DESCRIPTION
+ process group / privilege의 attributes를 문자열로 변환 하지 않고 원래 데이터(uint32_t)를 반환 하도록 변경
  - 디버그를 위해서 group / privilege attributes를 문자열로 덤프 하는 함수 추가
+ account flags를 문자열로 변환 하지 않고 원래 데이터(uint32_t)를 반환 하도록 변경
  - 디버그를 위해서 account flags를 문자열로 덤프 하는 함수 추가