### PR TITLE
ip에 해당하는 dns정보를 구하는 함수 추가

### DIFF
--- a/src/net_util.cpp
+++ b/src/net_util.cpp
@@ -431,7 +431,7 @@ SocketAddressToStr(
 bool
 dns_query(
 	_In_ uint32_t ip_netbyte_order,
-	_Out_ std::wstring& host_name
+	_Out_ std::wstring& domain_name
 	)
 {
 	std::string dns_query_ip;
@@ -449,11 +449,11 @@ dns_query(
 			dns_query_ip.c_str()
 			log_end;
 
-		host_name = L"";
+		domain_name = L"";
 		return false;
 	}
 
-	host_name = dns_record->Data.PTR.pNameHost;
+	domain_name = dns_record->Data.PTR.pNameHost;
 	return true;
 }
 

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -91,7 +91,7 @@ get_net_adapters(
 
 bool
 dns_query(
-	_In_ uint32_t addr_src,
+	_In_ uint32_t ip_netbyte_order,
 	_Out_ std::wstring& domain_name
 	);
 

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -92,7 +92,7 @@ get_net_adapters(
 bool
 dns_query(
 	_In_ uint32_t addr_src,
-	_Out_ std::wstring& host_name
+	_Out_ std::wstring& domain_name
 	);
 
 //

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -25,12 +25,22 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <iphlpapi.h>
+#include <WinDNS.h>
 
 //
 //	libs
 //
 #pragma comment(lib, "iphlpapi.lib")
 #pragma comment(lib, "ws2_32.lib")
+#pragma comment(lib, "Dnsapi.lib")
+
+typedef class NetIpInfo
+{
+public:
+	std::string ip;
+	uint32_t subnet_mask;
+
+} *PNetIpInfo;
 
 
 typedef class NetAdapter
@@ -41,8 +51,7 @@ public:
 	std::wstring desc;				// Marvell AVASTAR Wireless-AC Network Controller
 	std::string physical_address;	// BC-83-85-2D-8A-91
 
-	std::vector<std::string> ip_list;
-	std::vector<uint32_t> subnet_mask_list;
+	std::vector<PNetIpInfo> ip_info_list;
 	std::vector<std::string> dns_list;
 	std::vector<std::string> gateway_list;
 
@@ -80,7 +89,11 @@ get_net_adapters(
 	_Out_ std::vector<PNetAdapter>& adapters
 	);
 
-
+bool
+dns_query(
+	_In_ uint32_t addr_src,
+	_Out_ std::wstring& host_name
+	);
 
 //
 //	Win32Util 에 있던 Winsock 관련 함수들 


### PR DESCRIPTION
- ip에 해당하는 dns정보를 구하는 dns_query() 추가
  해당 함수는 로컬 DNS 캐쉬에서만 쿼리하도록 DNS_QUERY_NO_WIRE_QUERY 옵션을 사용했다.

- get_net_adapters()에서 ip와 net_mask에 대한 구조 변경