### PR TITLE
curl_client 리팩토링

### DIFF
--- a/_MyLib_test.cpp
+++ b/_MyLib_test.cpp
@@ -382,7 +382,7 @@ bool test_curl_https()
 
 	std::stringstream http_header;
 	http_header << "authorization: Bearer " 
-				<< "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX25hbWUiOiJzb21tYS10aS1sYWIifQ.Igu9sIhsflV7yM_C5jQSPWx-dOymBCGDTd3f5-b3z-I";
+				<< "FOO";
 
 	if (true != _curl_client->initialize(http_header.str().c_str(), 10, 90, 0))
 	{

--- a/_MyLib_test.cpp
+++ b/_MyLib_test.cpp
@@ -341,11 +341,11 @@ void run_test()
 	//assert_bool(true, test_set_binary_data);    
 	//assert_bool(true, test_aes256);
 
-	//assert_bool(true, test_curl_https);
-	//assert_bool(true, test_curl_http);
+	assert_bool(true, test_curl_https);
+	assert_bool(true, test_curl_http);
 	//assert_bool(true, test_alignment);
 	//assert_bool(true, test_create_string_from_buffer);
-	assert_bool(true, test_stop_watch);
+	//assert_bool(true, test_stop_watch);
 	
 //
 //	유닛테스트에 포함되지 않는 그냥 테스트용 코드
@@ -380,13 +380,18 @@ bool test_curl_https()
 		return false;
 	}
 
-	if (true != _curl_client->initialize())
+	std::stringstream http_header;
+	http_header << "authorization: Bearer " 
+				<< "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX25hbWUiOiJzb21tYS10aS1sYWIifQ.Igu9sIhsflV7yM_C5jQSPWx-dOymBCGDTd3f5-b3z-I";
+
+	if (true != _curl_client->initialize(http_header.str().c_str(), 10, 90, 0))
 	{
 		log_err "curl client initialize() failed." log_end;
 		return false;
 	}
 
-	const char* url = "https://api.somma.kr:44440/api/v1100/process";
+	const char* url = "https://api.somma.kr:55550/api/v1100/host-info";
+
 	std::string res;
 	_ASSERTE(true == _curl_client->http_get(url, res));
 	
@@ -410,7 +415,7 @@ bool test_curl_http()
 		return false;
 	}
 
-	const char* url = "http://192.168.10.133:8000/Hello_World";
+	const char* url = "http://192.168.10.200:5601/app/kibana#/monster?_g=()";
 	CMemoryStream stream;
 	_ASSERTE(true == _curl_client->http_get(url, stream));
 

--- a/src/curl_client.h
+++ b/src/curl_client.h
@@ -51,6 +51,8 @@
 //		}
 //
 
+static const char* _null_http_header_string = "";
+
 typedef class curl_client
 {
 public:
@@ -58,18 +60,25 @@ public:
 	~curl_client();
 
 public:
-	bool initialize();
+	bool initialize(_In_ const char* http_header = _null_http_header_string,
+					_In_ long connection_timeout = 10,
+					_In_ long read_timeout = 90,
+					_In_ long ssl_verifypeer = 1);
 	bool http_get(_In_ const char* url, _Out_ CMemoryStream& stream);
 	bool http_get(_In_ const char* url, _Out_ std::string& response);
 
 	bool http_post(_In_	const char* url, _In_ const std::string& body_data, _Out_ std::string& response);
 		
 private:
-	bool set_common_opt(_In_ const char* url, _Out_ CMemoryStream& stream);
+	bool set_common_opt(_In_ const char* http_header = _null_http_header_string,
+						_In_ long connection_timeout = 10,
+						_In_ long read_timeout = 90,
+						_In_ long ssl_verifypeer = 1);
 	bool perform();
 	void finalize();
 
 private:
-	CURL* _curl;
+	CURL*		_curl;
+	curl_slist* _header_items;
 
 } *pcurl_client;


### PR DESCRIPTION
+ curl_client, get/post 요청마다 기본 옵션을 매번 덮어 쓰고 있었음. 기본 설정은 initialize 함수 호출시 한 번 하는게 맞기 때문에 그렇게 변경
+ http_get 메소드에서만 custom http header를 생성해서 추가하도록 되어 있었음. post/get 모두 사용 할 수 있도록 header를 초기화 하도록 변경