### PR TITLE
cprocess_tree 리팩토링

### DIFF
--- a/_MyLib_test.cpp
+++ b/_MyLib_test.cpp
@@ -319,14 +319,11 @@ void run_test()
 
 	//assert_bool(true, test_initialize_string);
 
-	//uint32_t lt = get_log_to();
-	//set_log_to(log_to_con | lt);
-	//assert_bool(true, test_process_tree);
-	//assert_bool(true, test_iterate_process_tree);
-	//set_log_to(lt);
+	assert_bool(true, test_process_tree);
+	assert_bool(true, test_iterate_process_tree);	
+	assert_bool(true, test_image_path_by_pid);
+	assert_bool(true, test_get_process_creation_time);
 
-	//assert_bool(true, test_image_path_by_pid);
-	//assert_bool(true, test_get_process_creation_time);
 	//assert_bool(true, test_base64);
 	//assert_bool(true, test_random);
 	//assert_bool(true, test_ip_mac);

--- a/_test_process_token.cpp
+++ b/_test_process_token.cpp
@@ -6,25 +6,25 @@ bool test_process_token()
 {
 	cprocess_tree proc_tree;
 	_ASSERTE(true == proc_tree.build_process_tree(true));
-	proc_tree.iterate_process([](_In_ const process& proc)->bool
+	proc_tree.iterate_process([](_In_ const process* const proc)->bool
 	{
 		//
 		//	user
 		//
 		psid_info user_sid =nullptr;
-		user_sid = get_process_user(proc.pid());
+		user_sid = get_process_user(proc->pid());
 		if (nullptr == user_sid)
 		{
 			log_err "get_process_user() failed. pid=%u, image=%ws",
-				proc.pid(),
-				proc.process_name()
+				proc->pid(),
+				proc->process_name()
 				log_end;
 		}
 		else
 		{
 			log_info "== user, pid=%u, image=%ws, %ws\\%ws, sid=%ws, use=%u",
-				proc.pid(),
-				proc.process_name(),
+				proc->pid(),
+				proc->process_name(),
 				user_sid->_domain.c_str(),
 				user_sid->_name.c_str(),
 				user_sid->_sid.c_str(),
@@ -35,11 +35,11 @@ bool test_process_token()
 			//	groups
 			//
 			std::list<pgroup_sid_info> groups;
-			if (true != get_process_group(proc.pid(), groups))
+			if (true != get_process_group(proc->pid(), groups))
 			{
 				log_err "get_process_group() failed. pid=%u, image=%ws",
-					proc.pid(),
-					proc.process_name()
+					proc->pid(),
+					proc->process_name()
 					log_end;
 			}
 			else
@@ -69,11 +69,11 @@ bool test_process_token()
 			// privilege
 			//
 			std::list<pprivilege_info> privileges;
-			if (true != get_process_privilege(proc.pid(), privileges))
+			if (true != get_process_privilege(proc->pid(), privileges))
 			{
 				log_err "get_process_privilege() failed. pid=%u, image=%ws",
-					proc.pid(),
-					proc.process_name()
+					proc->pid(),
+					proc->process_name()
 					log_end;
 			}
 			else

--- a/_test_process_tree.cpp
+++ b/_test_process_tree.cpp
@@ -18,12 +18,12 @@
 			cmd.exe -> procexp.exe -> procexp64.exe(자동으로 만들어짐) -> notepad.exe
 			순서로 프로세스를 생성해 두고 해야 한다. 
 **/
-bool proc_tree_callback(_In_ const process& process_info)
+bool proc_tree_callback(_In_ const process* const process_info)
 {
     log_info "pid = %u, name = %ws, path = %ws", 
-		process_info.pid(), 
-		process_info.process_name(),
-		process_info.process_path()
+		process_info->pid(),
+		process_info->process_name(),
+		process_info->process_path()
 		log_end
 	return true;
 }
@@ -31,173 +31,191 @@ bool proc_tree_callback(_In_ const process& process_info)
 /// @brief	
 bool test_iterate_process_tree()
 {
-	cprocess_tree proc_tree;
-	if (!proc_tree.build_process_tree(true)) return false;
-
-	///	부모 프로세스가 없는 프로세스 목록을 먼저 생성한다. 
-	std::vector<pprocess> top_level_procs;
-	proc_tree.iterate_process([&](_In_ const process& process_info)->bool
+	_mem_check_begin
 	{
-		const process* p = proc_tree.get_parent(process_info);
-		if (nullptr == p)
+		cprocess_tree proc_tree;
+		if (!proc_tree.build_process_tree(true)) return false;
+
+		///	부모 프로세스가 없는 프로세스 목록을 먼저 생성한다. 
+		std::vector<const process*> top_level_procs;
+		proc_tree.iterate_process([&](_In_ const process* const process_info)->bool
 		{
-			top_level_procs.push_back(const_cast<pprocess>(&process_info));
-		}
+			const process* p = proc_tree.get_parent(process_info);
+			if (nullptr == p)
+			{
+				top_level_procs.push_back(process_info);
+			}
 
-		return true;
-	});
-
-	/// top_level_proces 와 그 자식 프로세스들을 부모->자식 순으로 iterate 한다. 
-	size_t count = 0;
-	for (auto& top_level_proc: top_level_procs)
-	{
-		log_info 
-			"processes tree under pid=%u, name=%ws, path=%ws", 
-			top_level_proc->pid(), 
-			top_level_proc->process_name(), 
-			top_level_proc->process_path()
-			log_end;
-
-		proc_tree.iterate_process_tree(*top_level_proc, 
-									   [&](_In_ const process& process_info)->bool 
-		{
-			log_info "    pid = %u, name = %ws, path = %ws",
-				process_info.pid(),
-				process_info.process_name(),
-				process_info.process_path()
-				log_end;
-
-			count++;
 			return true;
 		});
+
+		/// top_level_proces 와 그 자식 프로세스들을 부모->자식 순으로 iterate 한다. 
+		size_t count = 0;
+		for (auto& top_level_proc : top_level_procs)
+		{
+			log_info
+				"processes tree under pid=%u, name=%ws, path=%ws",
+				top_level_proc->pid(),
+				top_level_proc->process_name(),
+				top_level_proc->process_path()
+				log_end;
+
+			proc_tree.iterate_process_tree(top_level_proc,
+										   [&](_In_ const process* const process_info)->bool
+			{
+				log_info "    pid = %u, name = %ws, path = %ws",
+					process_info->pid(),
+					process_info->process_name(),
+					process_info->process_path()
+					log_end;
+
+				count++;
+				return true;
+			});
+		}
+		_ASSERTE(proc_tree.size() == count);
 	}
-	_ASSERTE(proc_tree.size() == count);
+	_mem_check_end;	
 	return true;
 }
 
 bool test_process_tree()
 {
-	cprocess_tree proc_tree;
-	if (!proc_tree.build_process_tree(true)) return false;
-
-	// 프로세스 열거 테스트 (by callback)
-	proc_tree.iterate_process(proc_tree_callback);
-	proc_tree.iterate_process_tree(proc_tree.find_process(L"cmd.exe"), proc_tree_callback);
-
-	// 프로세스 열거 테스트 (by lambda)
-	proc_tree.iterate_process([](_In_ const process& process_info)->bool 
+	_mem_check_begin
 	{
-		log_info "pid = %u, name = %ws, path = %ws",
-			process_info.pid(),
-			process_info.process_name(),
-			process_info.process_path()
-			log_end
+		cprocess_tree proc_tree;
+		if (!proc_tree.build_process_tree(true)) return false;
+
+		// 프로세스 열거 테스트 (by callback)
+		proc_tree.iterate_process(proc_tree_callback);
+		proc_tree.iterate_process_tree(proc_tree.find_process(L"cmd.exe"), 
+									   proc_tree_callback);
+
+		// 프로세스 열거 테스트 (by lambda)
+		proc_tree.iterate_process([](_In_ const process* const process_info)->bool
+		{
+			log_info "pid = %u, name = %ws, path = %ws",
+				process_info->pid(),
+				process_info->process_name(),
+				process_info->process_path()
+				log_end
+				return true;
+		});
+
+		// 프로세스 열거 테스트 (by boost::function, lambda with capture)
+		int count = 0;
+		auto callback = [&count](_In_ const process* const process_info)->bool
+		{
+			log_info "pid = %u, name = %ws, path = %ws",
+				process_info->pid(),
+				process_info->process_name(),
+				process_info->process_path()
+				log_end;
+			++count;
 			return true;
-	});
+		};
+		proc_tree.iterate_process(callback);
+		_ASSERTE(count > 0);
 
-	// 프로세스 열거 테스트 (by boost::function, lambda with capture)
-	int count = 0;
-	auto callback = [&count](_In_ const process& process_info)->bool
-	{
-		log_info "pid = %u, name = %ws, path = %ws",
-			process_info.pid(),
-			process_info.process_name(),
-			process_info.process_path()
-			log_end;
-		++count;
-		return true;
-	};
-	proc_tree.iterate_process(callback);
-	_ASSERTE(count > 0);
+		// 프로세스 열거 테스트 (by lambda with capture local variable)
+		count = 0;
+		proc_tree.iterate_process([&count](_In_ const process* const process_info)->bool
+		{
+			log_info "pid = %u, name = %ws, path = %ws",
+				process_info->pid(),
+				process_info->process_name(),
+				process_info->process_path()
+				log_end;
+			count++;
+			return true;
+		});
+		_ASSERTE(count > 0);
 
-	// 프로세스 열거 테스트 (by lambda with capture local variable)
-	count = 0;
-	proc_tree.iterate_process([&count](_In_ const process& process_info)->bool
-	{
-		log_info "pid = %u, name = %ws, path = %ws",
-			process_info.pid(),
-			process_info.process_name(),
-			process_info.process_path()
-			log_end;
-		count++;
-		return true;
-	});
-	_ASSERTE(count > 0);
+		// 
+		//	run notepad.exe & kill & ...
+		// 
+		PROCESS_INFORMATION pi = { 0 };
+		STARTUPINFOW si = { 0 }; si.cb = sizeof(si);
+		if (!CreateProcessW(L"c:\\windows\\system32\\notepad.exe",
+							nullptr,
+							nullptr,
+							nullptr,
+							FALSE,
+							0,
+							nullptr,
+							nullptr,
+							&si,
+							&pi))
+		{
+			log_err "CreateProcessW() failed. gle=%u",
+				GetLastError()
+				log_end;
+			return false;
+		}
+		Sleep(1000);
 
-	// 
-	//	run notepad.exe & kill & ...
-	// 
-	PROCESS_INFORMATION pi = { 0 };
-	STARTUPINFOW si = { 0 }; si.cb = sizeof(si);
-	if (!CreateProcessW(L"c:\\windows\\system32\\notepad.exe",
-						nullptr,
-						nullptr,
-						nullptr,
-						FALSE,
-						0,
-						nullptr,
-						nullptr,
-						&si,
-						&pi))
-	{
-		log_err "CreateProcessW() failed. gle=%u",
-			GetLastError()
-			log_end;
-		return false;
+		log_info "kill notepad..." log_end;
+		_ASSERTE(true == proc_tree.build_process_tree(false));
+		proc_tree.print_process_tree(L"notepad.exe");
+		_ASSERTE(true == proc_tree.kill_process_tree(proc_tree.find_process(L"notepad.exe"),
+													 false));
+
+		////
+		////	print process tree
+		////
+		//log_info "print explorer family..." log_end;
+		//proc_tree.print_process_tree(L"explorer.exe");
 	}
-	Sleep(1000);
-
-	log_info "kill notepad..." log_end;
-	_ASSERTE(true == proc_tree.build_process_tree(false));
-	proc_tree.print_process_tree(L"notepad.exe");
-	_ASSERTE(true == proc_tree.kill_process_tree(proc_tree.find_process(L"notepad.exe"), 
-												 false));
-
-	//
-	//	print process tree
-	//
-	log_info "print explorer family..." log_end;
-	proc_tree.print_process_tree(L"explorer.exe");
-	
+	_mem_check_end;
 	return true;
 }
 
 /// @brief	
 bool test_image_path_by_pid()
 {
-	cprocess_tree proc_tree;
-	if (!proc_tree.build_process_tree(true)) return false;
+	_mem_check_begin
+	{
+		cprocess_tree proc_tree;
+		if (!proc_tree.build_process_tree(true)) return false;
 
-	DWORD pid = proc_tree.find_process(L"explorer.exe");
+		DWORD pid = proc_tree.find_process(L"explorer.exe");
 
-	std::wstring win32_path;
-	std::wstring native_path;
-	if (!image_path_by_pid(pid, true, win32_path)) return false;
-	if (!image_path_by_pid(pid, false, native_path)) return false;
+		std::wstring win32_path;
+		std::wstring native_path;
+		if (!image_path_by_pid(pid, true, win32_path)) return false;
+		if (!image_path_by_pid(pid, false, native_path)) return false;
 
-	log_info "pid=%u, explorer.exe, \nwin32_path=%ws\nnative_path=%ws",
-		pid,
-		win32_path.c_str(),
-		native_path.c_str()
-		log_end;
+		log_info "pid=%u, explorer.exe, \nwin32_path=%ws\nnative_path=%ws",
+			pid,
+			win32_path.c_str(),
+			native_path.c_str()
+			log_end;
+	}
+	_mem_check_end;
+
 	return true;
 }
 
 /// @brief	
 bool test_get_process_creation_time()
 {
-	cprocess_tree proc_tree;
-	if (!proc_tree.build_process_tree(true)) return false;
+	_mem_check_begin
+	{
+		cprocess_tree proc_tree;
+		if (!proc_tree.build_process_tree(true)) return false;
 
-	DWORD pid = proc_tree.find_process(L"explorer.exe");
+		DWORD pid = proc_tree.find_process(L"explorer.exe");
 
-	FILETIME creation_time;
-	if (!get_process_creation_time(pid, &creation_time)) return false;
+		FILETIME creation_time;
+		if (!get_process_creation_time(pid, &creation_time)) return false;
 
-	log_info "pid=%u, explorer.exe, creation_time=%s",
-		pid,
-		file_time_to_str(&creation_time, true, true).c_str()
-		log_end;
+		log_info "pid=%u, explorer.exe, creation_time=%s",
+			pid,
+			file_time_to_str(&creation_time, true, true).c_str()
+			log_end;
+	}
+	_mem_check_end;
+
 
 	return true;
 }

--- a/src/process_tree.h
+++ b/src/process_tree.h
@@ -63,7 +63,7 @@ public:
 	DWORD			pid() const { return _pid; }
 	uint64_t		creation_time() const { return _creation_time; }	
 	bool			is_wow64() const { return _is_wow64; }
-	bool			killed() { return _killed; }
+	bool			killed() const { return _killed; }
 
 private:
 	std::wstring	_process_name;
@@ -75,18 +75,20 @@ private:
 	bool			_killed;
 } *pprocess;
 
+
 /**
  * @brief	place holder for running processes
 **/
-#pragma todo("process_map -> unique_ptr 로 변경하기")
-typedef std::map< DWORD, process >	process_map;
-typedef boost::function<bool(_In_ const process& process_info)> on_proc_walk;
+using process_map = std::map<DWORD, pprocess>;
+using on_proc_walk = boost::function<bool(_In_ const process* const process_info)>;
 
 class cprocess_tree
 {
 public:
+	virtual ~cprocess_tree();
+
 	size_t size() const { return _proc_map.size(); }
-	bool clear_process_tree() { _proc_map.clear(); }
+	void clear_process_tree();
 	bool build_process_tree(_In_ bool enable_debug_priv);
 
 	DWORD find_process(_In_ const wchar_t* process_name);
@@ -96,14 +98,14 @@ public:
 	const wchar_t* get_process_path(_In_ DWORD pid);
 	uint64_t get_process_time(_In_ DWORD pid);
 
-	const process* get_parent(_In_ const process& process);
+	const process* get_parent(_In_ const process* const process);
 	const process* get_parent(_In_ DWORD pid);
 	DWORD get_parent_pid(_In_ DWORD pid);
 	const wchar_t* get_parent_name(_In_ DWORD pid);
 
 	void iterate_process(_In_ on_proc_walk callback);
 	void iterate_process_tree(_In_ DWORD root_pid, _In_ on_proc_walk callback);
-	void iterate_process_tree(_In_ const process& root, _In_ on_proc_walk callback);
+	void iterate_process_tree(_In_ const process* const root, _In_ on_proc_walk callback);
 
 	void print_process_tree(_In_ DWORD root_pid);
 	void print_process_tree(_In_ const wchar_t* root_process_name);
@@ -114,8 +116,8 @@ public:
 	bool kill_process_tree(_In_ DWORD root_pid, _In_ bool enable_debug_priv);
 private:
 	void add_process(_In_ DWORD ppid, _In_ DWORD pid, _In_ FILETIME& creation_time, _In_ BOOL is_wow64, _In_ const wchar_t* process_name, _In_ std::wstring& full_path);
-	void print_process_tree(_In_ const process& p, _In_ DWORD& depth);
-	void kill_process_tree(_In_ process& root, _In_ bool enable_debug_priv);
+	void print_process_tree(_In_ const process* const p, _In_ DWORD& depth);
+	void kill_process_tree(_In_ process* const root, _In_ bool enable_debug_priv);
 private:
 	process_map _proc_map;
 };


### PR DESCRIPTION
- 내부 process tree 구성을 위한 map 객체 엔트리 타입을 process 객체가 아니라 process 포인터로 변경
- process 객체에 접근시 불필요한 복사등을 제거 함

Test:
    - test_process_tree()
    - test_iterate_process_tree()
    - test_image_path_by_pid()
    - test_get_process_creation_time()
Resolved: N/A
Related: N/A
---