### PR TITLE
MonsterU 설치 시 에러 로그 수정

### DIFF
--- a/src/sched_client.cpp
+++ b/src/sched_client.cpp
@@ -662,10 +662,7 @@ SchedClient::get_folder_info(
 	hres = _svc->GetFolder(_bstr_t(folder_name), folder);
 	if (!SUCCEEDED(hres))
 	{
-		log_err "_svc->GetFolder() failed. hres=%u, folder=%ws",
-			hres,
-			folder_name
-			log_end;
+		log_dbg "_svc->GetFolder() failed. folder=%ws", folder_name log_end;
 		return false;
 	}
 
@@ -691,17 +688,14 @@ SchedClient::get_task_register_info(
 	{
 		if (true != get_folder_info(folder_name, &folder))
 		{
-			//log_err "get_folder_info() failed. folder=%ws" log_end;
+			log_dbg "get_folder_info() failed. folder=%ws" log_end;
 			break;
 		}
 
 		hres = folder->GetTask(_bstr_t(task_name), registered_task);
 		if (!SUCCEEDED(hres))
 		{
-			log_err "folder->GetTask() failed. hres=%u, task_name=%ws",
-				hres,
-				task_name
-				log_end;
+			log_dbg "folder->GetTask() failed. task_name=%ws", task_name log_end;
 			break;
 		}
 		ret = true;


### PR DESCRIPTION
* MonsterU 업데이트 과정은 Uninstall -> install 과정으로 설치가 되는데 scheduler task가 등록되어 있지 않은 상태에서 Uninstall을 할 경우 get_task_register_info() 함수에서 scheduler task 찾을 수 없는 err 로그를 출력 한다.
* get_task_register_info() 함수에서는 로그를 err로 찍지 않고 dbg 모드로 찍도록 변경한다.