### PR TITLE
Dev/along 939

### DIFF
--- a/_MyLib_test.cpp
+++ b/_MyLib_test.cpp
@@ -800,7 +800,7 @@ bool test_random()
 bool test_ip_mac()
 {
 	std::wstring host_name;
-	std::vector<std::string> ip_list;
+	std::list<std::string> ip_list;
 
 	log_info "representative ip v4=%s",
 		get_representative_ip_v4().c_str()

--- a/_MyLib_test.cpp
+++ b/_MyLib_test.cpp
@@ -355,7 +355,7 @@ void run_test()
 	//assert_bool(true, test_str_to_xxx);
 	//assert_bool(true, test_set_get_file_position);
 	//assert_bool(true, test_get_module_path);
-	//assert_bool(true, test_dump_memory);
+	assert_bool(true, test_dump_memory);
 	//assert_bool(true, test_get_environment_value);
 	//assert_bool(true, test_get_account_infos);
 	//assert_bool(true, test_get_installed_programs);
@@ -425,7 +425,7 @@ void run_test()
 	//assert_bool(true, test_get_file_original_name);
 
 	//assert_bool(true, test_rvo_and_move);
-	assert_bool(true, test_cpp_joson);
+	//assert_bool(true, test_cpp_joson);
 
 	//assert_bool(true, test_template);
 //	유닛테스트에 포함되지 않는 그냥 테스트용 코드
@@ -1433,20 +1433,26 @@ bool test_get_module_path()
 **/
 bool test_dump_memory()
 {
+	auto lt = set_log_to(log_to_all);
+	
 	unsigned char buf[512] = {0};
-	RtlCopyMemory(buf, GetModuleHandle(NULL), 512);
+	RtlCopyMemory(buf, GetModuleHandle(NULL), 128);
 
-	std::vector<std::string> dump;
-	if (true != dump_memory(0, buf, sizeof(buf), dump)) return false;
-
-	std::vector<std::string>::iterator its = dump.begin();
-	std::vector<std::string>::iterator ite = dump.end();
-	for(; its != ite; ++its)
+	auto dump = dump_memory(0, buf, 6);
+	for (const auto& its: dump)
 	{
-		log_dbg "%s", its->c_str() log_end
+		log_info "%s", its.c_str() log_end
 	}
 
 	dump.clear();
+	dump = dump_memory(0, buf, 132);
+	for (const auto& its : dump)
+	{
+		log_info "%s", its.c_str() log_end
+
+	}
+
+	set_log_to(lt);
 	return true;
 }
 
@@ -1809,13 +1815,11 @@ bool test_enum_physical_drive()
             }
             else
             {
-                std::vector<std::string> dumps;
-                dump_memory(0, buf, sizeof(buf), dumps);
-                //for (auto line : dumps)
-                //{
-                //    log_info "%s", line.c_str() log_end;
-                //}
-                log_info "%ws, \n%s", path.str().c_str(), dumps[dumps.size() - 2].c_str() log_end;
+                auto dumps = dump_memory(0, buf, sizeof(buf));
+                for (auto line : dumps)
+                {
+                    log_info "%s", line.c_str() log_end;
+                }
             }
         }
         else
@@ -1892,8 +1896,7 @@ bool test_get_disk_volume_info()
         }
         else
         {
-            std::vector<std::string> dump;
-            dump_memory(0, buf, sizeof(buf), dump);
+            auto dump = dump_memory(0, buf, sizeof(buf));
             log_info "[*] MBR" log_end
             for (auto& line : dump)
             {
@@ -1922,8 +1925,7 @@ bool test_get_disk_volume_info()
             else
             {
                 log_info "[*] VBR" log_end
-                std::vector<std::string> dump;
-                dump_memory(0, buf, sizeof(buf), dump);
+                auto dump = dump_memory(0, buf, sizeof(buf));
                 for (auto& line : dump)
                 {
                     log_info "%s", line.c_str() log_end
@@ -2131,14 +2133,8 @@ void dump_file_offset(_In_ HANDLE file_handle, _In_ uint64_t offset, _In_ uint32
         return;
     }
 
-    std::vector<std::string> dump;
-    if (true != dump_memory(0, buf, size, dump))
-    {
-        log_err "dump_memory(0,  ) failed." log_end;
-        return;
-    }
-
-    for (auto& line : dump)
+	auto dump = dump_memory(0, buf, size);
+    for (const auto& line : dump)
     {
         log_info "%s", line.c_str() log_end
     }
@@ -3173,13 +3169,7 @@ bool test_raii_xxx()
 			break;
 		}
 
-		std::vector<std::string> dumps;
-		if (!dump_memory(0, buf, sizeof(buf), dumps))
-		{
-			log_err "dump_memory() failed." log_end;
-			break;
-		}
-
+		auto dumps = dump_memory(0, buf, sizeof(buf));
 		for (auto& dump : dumps)
 		{
 			log_info "%s", dump.c_str() log_end;

--- a/_test_curl.cpp
+++ b/_test_curl.cpp
@@ -167,9 +167,15 @@ bool test_curl_http()
 	CMemoryStream stream;
 	_ASSERTE(true == _curl_client->http_get(url, http_response_code, stream));
 
-	std::vector<std::string> dumps;
-	dump_memory(0LL, (unsigned char*)(stream.GetMemory()), (UINT32)stream.GetSize(), dumps);
-	std::for_each(dumps.begin(), dumps.end(), [](std::string& dump) {printf("%s\n", dump.c_str()); });
+	auto dumps = dump_memory(0LL, 
+							 (unsigned char*)(stream.GetMemory()), 
+							 (UINT32)stream.GetSize());
+	std::for_each(dumps.begin(), 
+				  dumps.end(), 
+				  [](std::string& dump) 
+	{
+		printf("%s\n", dump.c_str()); 
+	});
 
 	_ASSERTE(_curl_client != nullptr);
 	delete _curl_client; _curl_client = nullptr;

--- a/_test_dns_query.cpp
+++ b/_test_dns_query.cpp
@@ -120,7 +120,7 @@ bool test_dns_to_ip()
 {
 	_mem_check_begin
 	{
-		std::vector<uint32_t> ipz;
+		std::list<uint32_t> ipz;
 		_ASSERTE(true == dns_to_ip(L"naver.com", false, ipz));
 		log_info "naver.com :" log_end;
 		for (auto& ip : ipz)

--- a/_test_net_util.cpp
+++ b/_test_net_util.cpp
@@ -70,7 +70,7 @@ bool test_get_adapters()
 		init_net_util();
 		do
 		{
-			std::vector<PInetAdapter> adapters;
+			std::list<PInetAdapter> adapters;
 			_ASSERTE(true == get_inet_adapters(adapters));
 
 			for (auto& adapter : adapters)
@@ -109,8 +109,8 @@ bool test_get_addr_info()
 		
 		for (int i = 0; i < sizeof(host_names) / sizeof(wchar_t*); ++i)
 		{
-			std::vector<in_addr> ipv4_list;
-			std::vector<in_addr6> ipv6_list;
+			std::list<in_addr> ipv4_list;
+			std::list<in_addr6> ipv6_list;
 
 			_ASSERT(true == get_addr_infow(host_names[i],
 										   &ipv4_list,

--- a/src/Win32Utils.h
+++ b/src/Win32Utils.h
@@ -630,9 +630,7 @@ std::wstring guid_to_stringw(_In_ const GUID& guid);
 std::string Win32ErrorToStringA(IN DWORD ErrorCode);
 std::wstring Win32ErrorToStringW(IN DWORD ErrorCode);
 
-BOOL	DumpMemory(DWORD Length, BYTE* Buf);
-BOOL	DumpMemory(FILE* stream,DWORD Length,BYTE* Buf);
-bool	dump_memory(_In_ uint64_t base_offset, _In_ unsigned char* buf, _In_ UINT32 buf_len, _Out_ std::vector<std::string>& dump);
+std::list<std::string> dump_memory(_In_ uint64_t base_offset, _In_ unsigned char* buf, _In_ UINT32 buf_len);
 
 bool	set_privilege(_In_z_ const wchar_t* privilege, _In_ bool enable);
 

--- a/src/net_util.cpp
+++ b/src/net_util.cpp
@@ -127,7 +127,7 @@ get_host_name(
 ///	@param	net_family	AF_INET
 bool
 get_inet_adapters(	
-	_Out_ std::vector<PInetAdapter>& adapters
+	_Out_ std::list<PInetAdapter>& adapters
 )
 {
 	//
@@ -527,7 +527,7 @@ bool
 dns_to_ip(
 	_In_ const wchar_t* domain_name,
 	_In_ bool cache_only,
-	_Out_ std::vector<uint32_t>& ip_list
+	_Out_ std::list<uint32_t>& ip_list
 )
 {
 	std::string dns_query_ip;
@@ -731,6 +731,38 @@ str_to_ipv4(
 	return false;
 }
 
+/// @brief	
+uint32_t 
+str_to_ipv4(
+	_In_ const char* const ipv4
+)
+{
+	uint32_t nb_ip = 0;
+	if (!str_to_ipv4(ipv4, nb_ip))
+	{
+		return 0;
+	}
+	
+	return nb_ip;
+}
+
+/// @brief	
+uint32_t 
+str_to_ipv4(
+	_In_ const wchar_t* const ipv4
+)
+{
+	uint32_t nb_ip = 0;
+	if (!str_to_ipv4(ipv4, nb_ip))
+	{
+		return 0;
+	}
+
+	return nb_ip;
+}
+
+
+
 /// @brief  
 std::string
 ipv6_to_str(
@@ -846,10 +878,10 @@ str_to_ipv6(
 **/
 bool
 get_ip_list_v4(
-	_Out_ std::vector<std::string>& ip_list
+	_Out_ std::list<std::string>& ip_list
 )
 {
-	std::vector<PInetAdapter> adapters;
+	std::list<PInetAdapter> adapters;
 	if (true != get_inet_adapters(adapters))
 	{
 		log_err "get_inet_adapters() failed." log_end;
@@ -880,10 +912,10 @@ get_ip_list_v4(
 **/
 bool
 get_broadcast_list_v4(
-	_Out_ std::vector<uint32_t>& broadcast_list
+	_Out_ std::list<uint32_t>& broadcast_list
 )
 {
-	std::vector<PInetAdapter> adapters;
+	std::list<PInetAdapter> adapters;
 	if (true != get_inet_adapters(adapters))
 	{
 		log_err "get_inet_adapters() failed." log_end;
@@ -921,7 +953,7 @@ get_representative_ip_v4(
 	//	3순위: 
 	//		첫번째 IP
 	// 
-	std::vector<PInetAdapter> adapters;
+	std::list<PInetAdapter> adapters;
 	if (true != get_inet_adapters(adapters))
 	{
 		log_err "get_inet_adapters() failed." log_end;
@@ -1011,7 +1043,7 @@ get_mac_by_ip_v4(
 	//
 	//	어댑터 정보를 가져온다.
 	//
-	std::vector<PInetAdapter> adapters;
+	std::list<PInetAdapter> adapters;
 	if (true != get_inet_adapters(adapters))
 	{
 		log_err "get_inet_adapters() failed." log_end;
@@ -1086,8 +1118,8 @@ std::string mac_to_str(_In_ const MacAddrType mac)
 bool
 get_addr_infow(
 	_In_ const wchar_t* host_name,
-	_Out_opt_ std::vector<in_addr>* const ipv4_addrs,
-	_Out_opt_ std::vector<in6_addr>* const ipv6_addrs
+	_Out_opt_ std::list<in_addr>* const ipv4_addrs,
+	_Out_opt_ std::list<in6_addr>* const ipv6_addrs
 )
 {
 	_ASSERTE(nullptr != host_name);

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -52,13 +52,13 @@ get_host_name(
 
 bool
 get_inet_adapters(
-	_Out_ std::vector<PInetAdapter>& adapters
+	_Out_ std::list<PInetAdapter>& adapters
 );
 
 __inline 
 bool
 get_inet6_adapters(
-	_Out_ std::vector<PInet6Adapter>& adapters
+	_Out_ std::list<PInet6Adapter>& adapters
 )
 {
 	UNREFERENCED_PARAMETER(adapters);
@@ -76,7 +76,7 @@ bool
 dns_to_ip(
 	_In_ const wchar_t* domain_name,
 	_In_ bool cache_only,
-	_Out_ std::vector<uint32_t>& ip_list
+	_Out_ std::list<uint32_t>& ip_list
 );
 
 //
@@ -93,6 +93,8 @@ std::wstring ipv4_to_strw(_In_ in_addr& ipv4);
 
 bool str_to_ipv4(_In_ const char* const ipv4, _Out_ uint32_t& ip_netbyte_order);
 bool str_to_ipv4(_In_ const wchar_t* const ipv4, _Out_ uint32_t& ip_netbyte_order);
+uint32_t str_to_ipv4(_In_ const char* const ipv4);
+uint32_t str_to_ipv4(_In_ const wchar_t* const ipv4);
 
 
 std::string ipv6_to_str(_In_ in_addr6& ipv6); 
@@ -105,12 +107,12 @@ bool str_to_ipv6(_In_ const char* const ipv6, _Out_ in_addr6& ip_netbyte_order);
 
 bool
 get_ip_list_v4(
-	_Out_ std::vector<std::string>& ip_list
+	_Out_ std::list<std::string>& ip_list
 );
 
 bool
 get_broadcast_list_v4(
-	_Out_ std::vector<uint32_t>& broadcast_list
+	_Out_ std::list<uint32_t>& broadcast_list
 );
 
 std::string
@@ -130,8 +132,8 @@ mac_to_str(
 bool
 get_addr_infow(
 	_In_ const wchar_t* host_name,
-	_Out_opt_ std::vector<in_addr>* const ipv4_addrs,
-	_Out_opt_ std::vector<in6_addr>* const ipv6_addrs
+	_Out_opt_ std::list<in_addr>* const ipv4_addrs,
+	_Out_opt_ std::list<in6_addr>* const ipv6_addrs
 );
 
 

--- a/src/scm_context.cpp
+++ b/src/scm_context.cpp
@@ -182,28 +182,6 @@ install_fs_filter(
 	}
 
 	//
-	//	Open service manager for create new service
-	//
-	schandle_ptr scm_handle(OpenSCManagerW(NULL,
-										   NULL,
-										   SC_MANAGER_CREATE_SERVICE),
-							[](SC_HANDLE handle) {
-		if (nullptr != handle)
-		{
-			CloseServiceHandle(handle);
-		}
-	});
-
-	if (!scm_handle)
-	{
-		log_err
-			"OpenSCManagerW() faield. gle = %u",
-			GetLastError()
-			log_end;
-		return false;
-	}
-
-	//
 	//	Install Kernel driver service 
 	//
 	std::wstringstream sys_path;	
@@ -224,7 +202,7 @@ install_fs_filter(
 
 		sys_path
 			<< windows_dir
-			<< L"\\system32\\"
+			<< L"\\system32\\drivers\\"
 			<< file_name_from_file_pathw(bin_path);
 
 		//
@@ -260,6 +238,27 @@ install_fs_filter(
 		sys_path << bin_path;
 	}
 
+	//
+	//	Open service manager for create new service
+	//
+	schandle_ptr scm_handle(OpenSCManagerW(NULL,
+										   NULL,
+										   SC_MANAGER_CREATE_SERVICE),
+							[](SC_HANDLE handle) {
+		if (nullptr != handle)
+		{
+			CloseServiceHandle(handle);
+		}
+	});
+
+	if (!scm_handle)
+	{
+		log_err
+			"OpenSCManagerW() faield. gle = %u",
+			GetLastError()
+			log_end;
+		return false;
+	}
 
 	schandle_ptr svc_handle(CreateServiceW(scm_handle.get(),
 										   service_name,
@@ -274,7 +273,8 @@ install_fs_filter(
 										   L"FltMgr",
 										   nullptr,
 										   nullptr),
-							[](SC_HANDLE handle) {
+							[](SC_HANDLE handle) 
+	{
 		if (nullptr != handle)
 		{
 			CloseServiceHandle(handle);

--- a/src/scm_context.cpp
+++ b/src/scm_context.cpp
@@ -137,7 +137,8 @@ install_fs_filter(
 	_In_z_ const wchar_t* service_name,
 	_In_z_ const wchar_t* service_display_name,
 	_In_z_ const wchar_t* altitude,
-	_In_ uint32_t fs_filter_flag
+	_In_ const uint32_t fs_filter_flag, 
+	_In_ const DWORD start_type
 )
 {
 	_ASSERTE(nullptr != bin_path);
@@ -205,44 +206,61 @@ install_fs_filter(
 	//
 	//	Install Kernel driver service 
 	//
-	std::wstringstream sys_path;
-	DWORD start_type = SERVICE_AUTO_START;
-	DWORD service_type = SERVICE_KERNEL_DRIVER;
-#ifdef _DEBUG
-	sys_path << bin_path;
-#else
-	//
-	//	Release 버전에서는 `SERVICE_BOOT_START` 타입으로 설치한다.
-	// 
-	//	StartType = SERVICE_BOOT_START
-	//	으로 지정하려면 image file 의 경로가 반드시 system32 에 있어야한다.
-	//	따라서 드라이버 파일을 복사하고 복사된 경로의 드라이버를 서비스로 설치한다.
-	// 
-	std::wstring windows_dir;
-	if (!get_windows_dir(windows_dir))
+	std::wstringstream sys_path;	
+	DWORD service_type = SERVICE_KERNEL_DRIVER;	
+	if (start_type == SERVICE_BOOT_START)
 	{
-		log_err "get_windows_dir() failed. " log_end;
-		return false;
+		// 
+		//	StartType = SERVICE_BOOT_START 
+		//	으로 지정하려면 드라이버파일의 경로가 반드시 system32 에 있어야 함
+		// 
+	
+		std::wstring windows_dir;
+		if (!get_windows_dir(windows_dir))
+		{
+			log_err "get_windows_dir() failed. " log_end;
+			return false;
+		}
+
+		sys_path
+			<< windows_dir
+			<< L"\\system32\\"
+			<< file_name_from_file_pathw(bin_path);
+
+		//
+		//	현재 드라이버 파일의 경로가 system32\driver.sys 가 아니라면
+		//	기존 드라이버파일을 삭제하고, 현재 드라이버 파일을 복사한다.
+		//
+		if (0 != sys_path.str().compare(bin_path))
+		{
+			if (!DeleteFileW(sys_path.str().c_str()))
+			{
+				log_err
+					"Can not delete (old) fs driver. path=%ws, gle=%u",
+					sys_path.str().c_str(),
+					GetLastError()
+					log_end;
+				return false;
+			}
+
+			if (!CopyFile(bin_path, sys_path.str().c_str(), TRUE))
+			{
+				log_err
+					"Can not copy fs driver. src path=%ws, to path=%ws, gle=%u",
+					bin_path, 
+					sys_path.str().c_str(),
+					GetLastError()
+					log_end;
+				return false;
+			}
+		}
+	}
+	else
+	{
+		sys_path << bin_path;
 	}
 
-	sys_path
-		<< windows_dir
-		<< L"\\system32\\"
-		<< file_name_from_file_pathw(bin_path);
-	if (!CopyFile(bin_path, sys_path.str().c_str(), FALSE))
-	{
-		log_err
-			"Can not copy driver file to system directory. gle=%u",
-			GetLastError()
-			log_end;
-		return false;
-	}
 
-	//
-	//	SERVICE_KERNEL_DRIVER, 
-	//
-	start_type = SERVICE_BOOT_START;	
-#endif//_DEBUG
 	schandle_ptr svc_handle(CreateServiceW(scm_handle.get(),
 										   service_name,
 										   service_display_name,

--- a/src/scm_context.h
+++ b/src/scm_context.h
@@ -24,7 +24,8 @@ bool install_fs_filter(_In_z_ const wchar_t* bin_path,
 					   _In_z_ const wchar_t* service_name,
 					   _In_z_ const wchar_t* service_display_name,
 					   _In_z_ const wchar_t* altitude,
-					   _In_ uint32_t fs_filter_flag);
+					   _In_ const uint32_t fs_filter_flag, 
+					   _In_ const DWORD start_type);
 
 bool uninstall_service(_In_ const wchar_t* service_name);
 bool start_service(_In_ const wchar_t* service_name);


### PR DESCRIPTION
refactoring
+ install_fs_filter() 함수  
    - start type 을 인자로 받아, 필요한 경우 system32 디렉토리에 드라이버를 복사하는 기능 추
+ memory dump 함수
    - DumpMemory() 함수 제거
    - dump_memory() 함수 수정 (sting list 리턴하도록 변경)
---
fix: Driver install 경로 수정
- `\windows\system32\driver.sys` 경로를 사용하고 있었음
- `\windows\system32\drivers\driver.sys` 로 경로를 수정