### PR TITLE
feat: 서비스 Query 권한 에러

### DIFF
--- a/src/scm_context.cpp
+++ b/src/scm_context.cpp
@@ -937,7 +937,8 @@ bool service_started(_In_ const wchar_t* service_name)
 	//
 	schandle_ptr scm_handle(OpenSCManagerW(NULL,
 										   NULL,
-										   SC_MANAGER_ALL_ACCESS),
+										   STANDARD_RIGHTS_READ | SC_MANAGER_ENUMERATE_SERVICE |
+										   SC_MANAGER_QUERY_LOCK_STATUS),
 							[](SC_HANDLE handle) {
 		if (nullptr != handle)
 		{


### PR DESCRIPTION
* Service 상태를 쿼리하는 Serivce_started() 함수에서 모든 권한을 가지는 'SC_MANAGER_ALL_ACCESS`에서 `GENERIC_READ` 권한으로 변경