### PR TITLE
feat: 문자열 레지스트리 경로 분리 기능 추가

### DIFF
--- a/src/RegistryUtil.cpp
+++ b/src/RegistryUtil.cpp
@@ -914,3 +914,47 @@ reg_enum_key_values(
 
 	return true;
 }
+
+///	root key 
+bool
+str_to_reg_key(
+	_In_ const wchar_t* key_path,
+	_Out_ HKEY& key,
+	_Out_ std::wstring& sub_key
+)
+{
+	_ASSERTE(nullptr != key_path);
+	if (nullptr == key_path) return false;
+
+	std::wstring root_key_str = extract_first_tokenExW(key_path,
+													   L"\\",
+													   true);
+	to_lower_string(root_key_str);
+
+	bool ret = false;
+	do
+	{
+		if (0 == root_key_str.compare(_hklm_str) || 0 == root_key_str.compare(_hklm_full_str))
+		{
+			key = HKEY_LOCAL_MACHINE;
+		}
+		else if(0 == root_key_str.compare(_hkcu_str) || 0 == root_key_str.compare(_hkcu_full_str))
+		{
+			key = HKEY_CURRENT_USER;
+		}
+		else if (0 == root_key_str.compare(_hkcr_str) || 0 == root_key_str.compare(_hkcr_full_str))
+		{
+			key = HKEY_CLASSES_ROOT;
+		}
+		else
+		{
+			break;
+		}
+		sub_key = extract_first_tokenExW(key_path,
+										 L"\\",
+										 false);
+		ret = true;
+	} while (false);
+
+	return ret;
+}

--- a/src/RegistryUtil.h
+++ b/src/RegistryUtil.h
@@ -14,6 +14,15 @@
 #define MAX_KEY_LENGTH 255
 #define MAX_VALUE_NAME 16383
 
+
+/// 레지스트리 root 문자열
+#define _hklm_str		L"hklm"
+#define _hklm_full_str	L"hkey_local_machine"
+#define _hkcu_str		L"hkcu"
+#define _hkcu_full_str	L"hkey_current_user"
+#define _hkcr_str		L"hkcr"
+#define _hkcr_full_str	L"hkey_classes_root"
+
 HKEY 
 RUOpenKey(
 	_In_ HKEY RootKey, 
@@ -156,6 +165,13 @@ reg_enum_key_values(
 	_In_ fn_key_value_callback_tag value_cb,
 	_In_ DWORD_PTR value_cb_tag
 	);
+
+bool
+str_to_reg_key(
+	_In_ const wchar_t* key_path,
+	_Out_ HKEY& key,
+	_Out_ std::wstring& sub_key
+);
 
 class RegHandle
 {


### PR DESCRIPTION
* 문자열로 받은 레지스트리 경로에서 rook_key 와 sub_key로 분리 기능 추가

Test: N/A
Resolved: #94
Related: N/A