### PR TITLE
fix: 함수 리턴 타입 에러

### DIFF
--- a/_MyLib_test.vcxproj
+++ b/_MyLib_test.vcxproj
@@ -40,14 +40,14 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -55,7 +55,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -63,7 +63,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/FileIoHelperClass.cpp
+++ b/src/FileIoHelperClass.cpp
@@ -497,7 +497,7 @@ FileIoHelper::GetFilePointer(
 		return nullptr;
 	}
 
-	if (true != Initialized()) return false;
+	if (true != Initialized()) return nullptr;
 	if (IsReadOnly() && !read_only)
 	{
 		log_err "file mapped read only." log_end;

--- a/src/RegistryUtil.cpp
+++ b/src/RegistryUtil.cpp
@@ -749,7 +749,7 @@ RUReadBinaryData(
 {
 	_ASSERTE(nullptr != key_handle);
 	_ASSERTE(nullptr != value_name);
-	if (nullptr == key_handle || nullptr == value_name) return false;
+	if (nullptr == key_handle || nullptr == value_name) return nullptr;
 
 	void* old = nullptr;
 	cbValue = 1024;
@@ -812,7 +812,7 @@ RUReadBinaryDataEx(
 		nullptr == sub_key ||
 		nullptr == value_name)
 	{
-		return false;
+		return nullptr;
 	}
 
 	RegHandle rh(RUOpenKey(key_handle, sub_key, true, disable_wow));

--- a/src/Win32Utils.cpp
+++ b/src/Win32Utils.cpp
@@ -5079,7 +5079,7 @@ std::wstring get_current_module_fileEx()
 std::wstring device_name_from_nt_name(_In_ const wchar_t* nt_name)
 {
 	_ASSERTE(NULL != nt_name);
-	if (NULL == nt_name) return false;
+	if (NULL == nt_name) return _null_stringw;
 
 	// 문자열 길이를 계산
 	// input: \Device\HarddiskVolume4\
@@ -7702,7 +7702,7 @@ get_privilege_info(
 			"LookupPrivilegeNameW failed. gle=%u",
 			GetLastError()
 			log_end;
-		return false;
+		return nullptr;
 	}
 
 

--- a/src/machine_id.h
+++ b/src/machine_id.h
@@ -8,6 +8,7 @@
 **/
 #pragma once
 #include "BaseWindowsHeader.h"
+#include <intrin.h>
 
 bool generate_machine_id(_Out_ std::string& machine_id);
 

--- a/src/net_util.cpp
+++ b/src/net_util.cpp
@@ -1059,7 +1059,7 @@ get_mac_by_ip_v4(
 )
 {
 	_ASSERTE(nullptr != ip_str);
-	if (nullptr == ip_str) return false;
+	if (nullptr == ip_str) return "00-00-00-00-00-00";
 
 	uint32_t ip = 0xffffffff;
 	if (true != str_to_ipv4(MbsToWcsEx(ip_str).c_str(), ip))


### PR DESCRIPTION
#### Visual Studio 2019부터 리턴 타입이 다를 경우 컴파일 에러 발생
* 리턴 타입을 동일하게 수정 
  * FileIoHelper::GetFilePointer
  * RUReadBinaryData
  * RUReadBinaryDataEx
  * device_name_from_nt_name
  * get_privilege_info
  * get_mac_by_ip_v4

Test: N/A
Resolved: N/A
Related: N/A